### PR TITLE
Fungible tokens: The Either bit is required in TIP-74

### DIFF
--- a/ft/jetton-wallet.fc
+++ b/ft/jetton-wallet.fc
@@ -57,6 +57,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   slice response_address = in_msg_body~load_msg_addr();
   cell custom_payload = in_msg_body~load_dict();
   int forward_ton_amount = in_msg_body~load_coins();
+  throw_unless(708, slice_bits(in_msg_body) >= 1);
   slice either_forward_payload = in_msg_body;
   var msg = begin_cell()
     .store_uint(0x18, 6)


### PR DESCRIPTION
In the current implementation, the smart contract does not throw an error on messages that do not comply with the standard