### PR TITLE
fix ERESOLVE error up @ton/core version to 0.59.0, 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@swc/core": "^1.3.102",
     "@ton/blueprint": "^0.15.0",
-    "@ton/core": "^0.53.0",
+    "@ton/core": "^0.59.0",
     "@ton/sandbox": "^0.15.0",
     "@ton/test-utils": "^0.4.2",
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: undefined@undefined
npm error Found: @ton/core@0.53.0
npm error node_modules/@ton/core
npm error   dev @ton/core@"^0.53.0" from the root project
npm error   peer @ton/core@">=0.49.2" from @ton/blueprint@0.15.0
npm error   node_modules/@ton/blueprint
npm error     dev @ton/blueprint@"^0.15.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @ton/core@">=0.59.0" from @ton/ton@15.1.0
npm error node_modules/@ton/ton
npm error   peer @ton/ton@">=13.4.1" from @ton/blueprint@0.15.0
npm error   node_modules/@ton/blueprint
npm error     dev @ton/blueprint@"^0.15.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.